### PR TITLE
Pass autoprefixer options

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,4 +3,6 @@
 var HTMLPostCSS = require('html-postcss');
 var autoprefixer = require('autoprefixer');
 
-module.exports = new HTMLPostCSS([autoprefixer]);
+module.exports = function(autoprefixerConfig) {
+  return new HTMLPostCSS([autoprefixer(autoprefixerConfig)]);
+};

--- a/test/main.js
+++ b/test/main.js
@@ -2,7 +2,7 @@
 
 var expect = require('chai').expect;
 
-var htmlAutoprefixer = require('../');
+var htmlAutoprefixer = require('../')();
 
 describe('html-autoprefixer', function() {
   describe('#process', function() {


### PR DESCRIPTION
This change allows options to be passed to autoprefixer.
It is a breaking change, but as can be seen in the tests, migration is easy.
